### PR TITLE
Speed up running tests

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -272,7 +272,7 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
-        consensus.powLimit = uint256S("0x3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        consensus.powLimit = uint256S("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 90;
         consensus.fPowAllowMinDifficultyBlocks = true;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -70,6 +70,10 @@ unsigned int static DarkGravityWaveZeny(const CBlockIndex* pindexLast, const Con
         return bnPowLimit.GetCompact();
     }
 
+    // Just return when the chain doesn't expect re-targeting
+    if (params.fPowNoRetargeting)
+        return bnPowLimit.GetCompact();
+
     const CBlockIndex *pindex = pindexLast;
     arith_uint256 bnPastTargetAvg = 0;
 


### PR DESCRIPTION
* Change RegTest chain parameter: `powLimit`
* Enable RegTest chain parameter: `fPowNoRetargeting`

Now, test_bitcoin is completed around 1 minute.
Related Issue: #35 