### PR TITLE
Fix an invalid comment: 95% >> 100%

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -84,7 +84,7 @@ public:
         consensus.nPowTargetSpacing = 90;
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
-        consensus.nRuleChangeActivationThreshold = 13440; // 95%
+        consensus.nRuleChangeActivationThreshold = 13440; // 100%
         consensus.nMinerConfirmationWindow = 13440; // nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008


### PR DESCRIPTION
https://github.com/bitzenyPlus/BitZenyPlus/issues/41

I think this `100%` is not good for the consensus. We need a discussion about this in near future.

Fixing a comment is a trivial thing, but this parameter is important thing.